### PR TITLE
Implemented ImagePicker in LeaveFormActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+
     <application
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"

--- a/app/src/main/java/com/example/myleave/ui/user/LeaveFormActivity.kt
+++ b/app/src/main/java/com/example/myleave/ui/user/LeaveFormActivity.kt
@@ -1,9 +1,19 @@
 package com.example.myleave.ui.user
 
+import android.Manifest
+import android.app.Activity
 import android.app.DatePickerDialog
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
+import android.provider.OpenableColumns
+import android.provider.Settings
 import android.widget.ArrayAdapter
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import com.example.myleave.R
 import com.example.myleave.databinding.ActivityLeaveFormBinding
 import java.text.SimpleDateFormat
@@ -15,6 +25,10 @@ class LeaveFormActivity : AppCompatActivity() {
     private lateinit var binding: ActivityLeaveFormBinding
     private lateinit var startDate: Date
     private lateinit var endDate: Date
+    private val PICK_FILE_REQUEST_CODE = 1
+    private val REQUEST_PERMISSION_CODE = 2
+    private val requiredPermission = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +68,115 @@ class LeaveFormActivity : AppCompatActivity() {
             openDatePicker(1)
         }
 
+        binding.ibChooseFile.setOnClickListener() {
+
+            if (isPermissionGranted()) {
+                openFilePicker()
+            } else {
+                requestPermission()
+            }
+
+
+        }
+
+    }
+
+    private fun isPermissionGranted(): Boolean {
+        return ContextCompat.checkSelfPermission(
+            this,
+            Manifest.permission.READ_EXTERNAL_STORAGE
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    private fun requestPermission() {
+        ActivityCompat.requestPermissions(
+            this,
+            requiredPermission,
+            REQUEST_PERMISSION_CODE
+        )
+
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == REQUEST_PERMISSION_CODE
+            && grantResults.isNotEmpty()
+            && grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
+            openFilePicker()
+        } else {
+            showSettingDialog()
+        }
+    }
+
+    private fun showSettingDialog() {
+        AlertDialog.Builder(this)
+            .setTitle("Permission Required")
+            .setMessage("This app needs access to your storage to upload files.")
+            .setPositiveButton("Go to Settings") { dialog, _ ->
+                val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+                    data = Uri.fromParts("package", packageName, null)
+                }
+                startActivity(intent)
+                dialog.dismiss()
+            }
+            .setNegativeButton("Cancel") { dialog, _ ->
+                dialog.dismiss()
+            }
+            .show()
+    }
+
+    private fun openFilePicker() {
+        val intent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = "*/*"
+            putExtra(Intent.EXTRA_MIME_TYPES, arrayOf("application/pdf", "image/*"))
+            addCategory(Intent.CATEGORY_OPENABLE)
+
+        }
+        startActivityForResult(intent, PICK_FILE_REQUEST_CODE)
+
+    }
+
+    @Deprecated("This method has been deprecated in favor of using the Activity Result API")
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == PICK_FILE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
+            data?.data?.let { uri ->
+                handleFileUri(uri)
+            }
+        }
+    }
+
+    private fun handleFileUri(uri: Uri) {
+        val fileName = getFileName(uri)
+        binding.etAttachment.setText(fileName)
+    }
+
+    private fun getFileName(uri: Uri): String? {
+        var result: String? = null
+        if (uri.scheme == "content") {
+            val cursor = contentResolver.query(uri, null, null, null, null)
+            cursor?.use {
+                if (it.moveToFirst()) {
+                    result = it.getString(it.getColumnIndexOrThrow(OpenableColumns.DISPLAY_NAME))
+                }
+            }
+        }
+        if (result == null) {
+            result = uri.path
+            val cut = result?.lastIndexOf('/')
+            if (cut != -1) {
+                result = result?.substring(cut!! + 1)
+            }
+        }
+        if (result == "" || result == null) {
+            result = "Unknown file"
+        }
+        return result
     }
 
     private fun openDatePicker(check: Int) {


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #25 .
2. This PR does the following:   
    i) ask user for permission 
    ii) after denying the permission if user tries to excess file user will be directed to the setting to give permission.
    iii) user is able to select image and pdf only.
    iv) the name of the selected file is shown in the attachment textview.

## Essential Checklist


## Proof that changes are correct
![image1](https://github.com/bsoc-bitbyte/myLeave/assets/161844562/0ebce2c8-fa02-4240-9b43-56f4e617b006)
![image2](https://github.com/bsoc-bitbyte/myLeave/assets/161844562/9f22f60e-ae6d-4551-a08e-771ffc6bb845)
![image3](https://github.com/bsoc-bitbyte/myLeave/assets/161844562/35d14147-44aa-4537-819c-33ad34ca8464)




## PR Pointers


